### PR TITLE
ANSI codeblock implementation + discord.py compatibility fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# ticket_bot
+You can find an example [here](https://github.com/jvherck/ticket_bot/blob/master/src/ansi_example.py).
+
+## IMPORTANT
+I suggest you use `io.BytesIO(Transcript.encoded)` like in the example, if you're sending it as a `discord.File`. \
+This encoding (`cp1252`) allows special ANSI characters to exist and won't turn them into weird characters, so it doesn't f*ck up your html transcript. \
+You can still just get the standard html string by using `Transcript.html`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ discord
 discord-py-slash-command
 requests
 pytz
-emoji
+emoji==1.6.3
 grapheme
+ansi2html

--- a/src/ansi_example.py
+++ b/src/ansi_example.py
@@ -1,0 +1,54 @@
+import discord
+from discord.ext import commands
+from io import BytesIO
+from os import environ
+
+import libs.chat_exporter as chat_exporter
+from libs.chat_exporter.chat_exporter import Transcript
+
+intents = discord.Intents.all()
+bot = commands.Bot(command_prefix=("t.",), case_insensitive=True, intents=intents)
+
+TOKEN = environ["TOKEN"]
+
+
+@bot.event
+async def on_ready():
+    chat_exporter.init_exporter(bot)
+    print("READY")
+
+
+bb = "\u001b[34;1m" # bright blue
+w = "\u001b[37m" # white
+r = "\u001b[31m" # red
+g = "\u001b[32m" # green
+b = "\u001b[1m" # bold
+u = "\u001b[4m" # underline
+re = "\u001b[0m" # reset
+ansi = f"```ansi\n" \
+       f"{bb+b+u}All Plugins:{re}\n\t{w}automod, modmail, giveaways, tickets, config{re}\n\u200b\n" \
+       f"{bb+b+u}Enabled Plugins:{re}\n\t{g}modmail, tickets, config{re}\n\u200b\n" \
+       f"{bb+b+u}Disabled Plugins:{re}\n\t{r}automod, giveaways{re}\n\u200b\n" \
+       f"```"
+
+
+@bot.command(aliases=["ex"])
+async def example(ctx):
+    await ctx.send(ansi)
+
+    messages = [message async for message in ctx.channel.history(limit=20)]
+    transcript: Transcript = await chat_exporter.raw_export(ctx.channel, messages)
+
+    # using `transcript.encoded` will avoid weird characters showing up (encoding="cp1252")
+    # use `transcript.html` if you want the standard html string
+    file = discord.File(BytesIO(transcript.encoded), "transcript.html")
+
+    msg = await ctx.channel.send("Logging Channel...", file=file)
+    await msg.edit(content="Channel logged.",
+                   embed=discord.Embed(
+                       title="Transcript",
+                       description=f"[Link to transcript](https://fileviewer.janvh.tk?url={msg.attachments[0].url})"
+                   ))
+
+
+bot.run(TOKEN)

--- a/src/ansi_example.py
+++ b/src/ansi_example.py
@@ -44,6 +44,8 @@ async def example(ctx):
     file = discord.File(BytesIO(transcript.encoded), "transcript.html")
 
     msg = await ctx.channel.send("Logging Channel...", file=file)
+
+    # By sending the file first, we can the url of that file and add it to the url of the online file viewer
     await msg.edit(content="Channel logged.",
                    embed=discord.Embed(
                        title="Transcript",

--- a/src/libs/chat_exporter/build_embed.py
+++ b/src/libs/chat_exporter/build_embed.py
@@ -5,6 +5,11 @@ from .build_html import fill_out, embed_body, embed_title, embed_description, em
     PARSE_MODE_EMBED, PARSE_MODE_SPECIAL_EMBED, PARSE_MODE_NONE, PARSE_MODE_MARKDOWN
 
 
+try:
+    EmptyEmbed = discord.Embed.Empty
+except AttributeError:
+    EmptyEmbed = None
+
 class BuildEmbed:
     r: str
     g: str
@@ -36,12 +41,12 @@ class BuildEmbed:
 
     def build_colour(self):
         self.r, self.g, self.b = (self.embed.colour.r, self.embed.colour.g, self.embed.colour.b) \
-            if self.embed.colour != discord.Embed.Empty \
+            if self.embed.colour != EmptyEmbed \
             else (0x20, 0x22, 0x25)  # default colour
 
     async def build_title(self):
         self.title = self.embed.title \
-            if self.embed.title != discord.Embed.Empty \
+            if self.embed.title != EmptyEmbed \
             else ""
 
         if self.title != "":
@@ -51,7 +56,7 @@ class BuildEmbed:
 
     async def build_description(self):
         self.description = self.embed.description \
-            if self.embed.description != discord.Embed.Empty \
+            if self.embed.description != EmptyEmbed \
             else ""
 
         if self.description != "":
@@ -74,18 +79,18 @@ class BuildEmbed:
 
     async def build_author(self):
         self.author = self.embed.author.name \
-            if self.embed.author.name != discord.Embed.Empty \
+            if self.embed.author.name != EmptyEmbed \
             else ""
 
         self.author = f'<a class="chatlog__embed-author-name-link" href="{self.embed.author.url}">{self.author}</a>' \
-            if self.embed.author.url != discord.Embed.Empty \
+            if self.embed.author.url != EmptyEmbed \
             else self.author
 
         author_icon = await fill_out(self.guild, embed_author_icon, [
             ("AUTHOR", self.author, PARSE_MODE_NONE),
             ("AUTHOR_ICON", self.embed.author.icon_url, PARSE_MODE_NONE)
         ]) \
-            if self.embed.author.icon_url != discord.Embed.Empty \
+            if self.embed.author.icon_url != EmptyEmbed \
             else ""
 
         if author_icon == "" and self.author != "":
@@ -97,21 +102,21 @@ class BuildEmbed:
         self.image = await fill_out(self.guild, embed_image, [
             ("EMBED_IMAGE", str(self.embed.image.proxy_url), PARSE_MODE_NONE)
         ]) \
-            if self.embed.image.url != discord.Embed.Empty \
+            if self.embed.image.url != EmptyEmbed \
             else ""
 
     async def build_thumbnail(self):
         self.thumbnail = await fill_out(self.guild, embed_thumbnail, [
             ("EMBED_THUMBNAIL", str(self.embed.thumbnail.url), PARSE_MODE_NONE)]) \
-            if self.embed.thumbnail.url != discord.Embed.Empty \
+            if self.embed.thumbnail.url != EmptyEmbed \
             else ""
 
     async def build_footer(self):
         footer = self.embed.footer.text \
-            if self.embed.footer.text != discord.Embed.Empty \
+            if self.embed.footer.text != EmptyEmbed \
             else ""
         footer_icon = self.embed.footer.icon_url \
-            if self.embed.footer.icon_url != discord.Embed.Empty \
+            if self.embed.footer.icon_url != EmptyEmbed \
             else None
 
         if footer != "":

--- a/src/libs/chat_exporter/chat_exporter.py
+++ b/src/libs/chat_exporter/chat_exporter.py
@@ -49,7 +49,7 @@ async def raw_export(
 ):
     # noinspection PyBroadException
     try:
-        return (await Transcript.raw_export(channel, messages, set_timezone)).html
+        return await Transcript.raw_export(channel, messages, set_timezone)
     except Exception:
         traceback.print_exc()
         print(f"Please send a screenshot of the above error to https://www.github.com/mahtoid/DiscordChatExporterPy")
@@ -98,6 +98,10 @@ class Transcript:
     messages: List[discord.Message]
     timezone_string: str
     html: Optional[str] = None
+    encoded: Optional[bytes] = None # This is able to store the html file without having those weird characters
+    # io.BytesIO(Transcript.encoded) -> BytesIO object
+    # io.BytesIO(Transcript.encoded).read() -> bytes object
+    # io.BytesIO(Transcript.encoded).read().decode(encoding="UTF-8") -> str object
 
     @classmethod
     async def export(
@@ -173,6 +177,7 @@ class Transcript:
             ("MESSAGES", message_html, PARSE_MODE_NONE),
             ("TIMEZONE", str(self.timezone_string)),
         ])
+        self.encoded = self.html.encode("cp1252")
 
 
 class Message:

--- a/src/libs/chat_exporter/chat_exporter_html/base.html
+++ b/src/libs/chat_exporter/chat_exporter_html/base.html
@@ -789,7 +789,9 @@
     <script>
       document.addEventListener("DOMContentLoaded", () => {
         document.querySelectorAll(".pre--multiline").forEach((block) => {
-          hljs.highlightBlock(block);
+          if (!block.classList.includes("nohljs")){
+            hljs.highlightBlock(block);
+          }
         });
       });
     </script>


### PR DESCRIPTION
### Added ANSI codeblock
I have added ANSI to the markdown languages. This does require an extra package to be installed `ansi2html`, which I have added to the requirements.

### Added example file
I've added an [example file](https://github.com/jvherck/ticket_bot/blob/master/src/ansi_example.py) that shows the ANSI output. \
I suggest you base your own code onto my example (more specifically how to send the html string as file in Discord) as this should always work in any scenario. \
I have provided a link in my example too which is able to show the html file without downloading anything.

### Compatibility fixes
I've also made some compatibility fixes: 
- made it possible for both discord.py<=1.7.3 and discord.py>=2.0.1 to work
- added a specific version to `emoji` package in requirements.txt because the used function has been removed in newer versions

---

I might improve the looks of the exported chat too as I've already done this for my personal projects.